### PR TITLE
Document Pico 2 SWD, J4 jumper, USB boot, and digital inputs

### DIFF
--- a/src/content/docs/dmx-core-pico-2-re-mapper/faq.md
+++ b/src/content/docs/dmx-core-pico-2-re-mapper/faq.md
@@ -15,6 +15,16 @@ The Pico 2 draws about 30mA at 12V, less than 1 watt.
 
 Yes, the re-mapper is built on the exact same hardware as the DMX Core Pico 2, but it comes bundled and pre-loaded with the Re-Mapper firmware and config utility. You can run any Raspberry Pi Pico firmware on the hardware and later re-flash the Re-Mapper firmware.
 
+Programming is the standard RP2040 USB UF2 flow (hold BOOTSEL, copy a `.uf2` file). Arduino IDE works if you select **Raspberry Pi Pico (RP2040)**. J3 is the SWD debug port (JST SH 1.0 mm) if you want to attach a J-Link or Raspberry Pi Debug Probe. See the [Pico 2 Software](/dmx-core-pico-2/software/) and [Pin out](/dmx-core-pico-2/pin-out/) pages.
+
+### Are the digital triggers pulled to GND to activate?
+
+No. Apply 3–24 VDC between the input (`i1`–`i4`) and `C`. For a push button, fit jumper J4 (Connect C to GND) and switch the onboard `3v3` onto the input. See [Pin out](/dmx-core-pico-2/pin-out/#digital-inputs).
+
+### What does the J4 jumper "Connect C to GND" mean?
+
+It connects the digital-input common (`C`) to board ground. Fit it when using onboard 3.3 V for buttons; leave it open when an external 3–24 V source has its own return on `C`.
+
 ### Is the Re-Mapper firmware source code available/open source?
 
 At this time the firmware and config utility are not made available as open source.

--- a/src/content/docs/dmx-core-pico-2-re-mapper/index.md
+++ b/src/content/docs/dmx-core-pico-2-re-mapper/index.md
@@ -36,7 +36,7 @@ Configuration via text-based configuration tool, connected via USB to a Windows 
 
 ### Hardware
 
-The Re-Mapper solution is software (firmware + configuration tool) that runs on the [DMX Core Pico 2](/dmx-core-pico-2/) hardware. The hardware has additional features like digital inputs/outputs that are not currently used by the Re-Mapper code.
+The Re-Mapper solution is software (firmware + configuration tool) that runs on the [DMX Core Pico 2](/dmx-core-pico-2/) hardware. Digital inputs, digital outputs, the USB UF2 bootloader, and the J3 SWD debug header are part of that hardware; see the [Pico 2 pin out](/dmx-core-pico-2/pin-out/) and [software](/dmx-core-pico-2/software/) pages.
 
 ### Mounting
 

--- a/src/content/docs/dmx-core-pico-2-re-mapper/pin-out.md
+++ b/src/content/docs/dmx-core-pico-2-re-mapper/pin-out.md
@@ -2,6 +2,8 @@
 title: Pin out
 ---
 
+The Re-Mapper uses the same hardware as the [DMX Core Pico 2](/dmx-core-pico-2/pin-out/). DMX, digital I/O, the J3 SWD debug connector, and jumper J4 are documented there.
+
 ## DMX pin out
 
 * G - `Ground/Common` - pin 1
@@ -11,3 +13,9 @@ title: Pin out
 ![XLR-3](/assets/dmx-core-pico-2-re-mapper/xlr3.png)
 
 ![XLR-5](/assets/dmx-core-pico-2-re-mapper/xlr5.png)
+
+## Digital inputs (Re-Mapper)
+
+The 4 digital inputs can drive mapped DMX channels even when there is no DMX input. They are **active when 3–24 VDC is applied** between `i1`–`i4` and `C`, not when the pin is pulled to GND.
+
+For push buttons, fit jumper J4 (**Connect C to GND**) and wire each button between the `3v3` pin and an input. Full wiring is on the [Pico 2 pin out](/dmx-core-pico-2/pin-out/#digital-inputs) page.

--- a/src/content/docs/dmx-core-pico-2/faq.md
+++ b/src/content/docs/dmx-core-pico-2/faq.md
@@ -6,3 +6,19 @@ description: Frequently Asked Questions
 #### How can I power the Pico 2?
 
 The Pico 2 can be powered either via USB-C at 5V, or via the power input connector at 7-28VDC.
+
+#### Is J3 DEBUG the SWD port? What connector is it?
+
+Yes. J3 is the RP2040 Serial Wire Debug (SWD) port. It is a 3-pin **JST SH 1.0 mm** connector (`BM03B-SRSS-TB`), the same type used on a Raspberry Pi Pico H and the Raspberry Pi Debug Probe. Pinout: 1 = SWCLK, 2 = GND, 3 = SWDIO. See [Pin out](pin-out/#j3-debug-swd) for J-Link wiring.
+
+#### Are you using a bootloader through the USB port? Can I use the Arduino IDE?
+
+The RP2040 USB bootloader is in ROM. Hold **BOOTSEL**, connect USB, and copy a `.uf2` file to the `RPI-RP2` drive. Arduino IDE works if you select **Raspberry Pi Pico (RP2040)** — not Pico 2 / RP2350. Details are on the [Software](software) page.
+
+#### What does the J4 jumper "Connect C to GND" mean?
+
+J4 ties the digital-input common (`C`) to board ground. Fit the jumper when using the onboard `3v3` pin to power buttons or dry contacts. Leave it open when an external 3–24 V source brings its own 0 V to `C`. See [Pin out](pin-out/#j4-jumper).
+
+#### Are the digital triggers pulled to GND to activate?
+
+No. Apply **3–24 VDC** between the input (`i1`–`i4`) and `C`. For a push button, jumper J4 and switch the onboard `3v3` onto the input. See [Pin out](pin-out/#digital-inputs).

--- a/src/content/docs/dmx-core-pico-2/pin-out.md
+++ b/src/content/docs/dmx-core-pico-2/pin-out.md
@@ -12,6 +12,65 @@ title: Pin out
 
 ![XLR-5](/assets/dmx-core-pico-2/xlr5.png)
 
+## Digital inputs
+
+The input terminal is labeled `C  3v3  i4   i3   i2   i1`.
+
+| Pin | Function |
+| --- | --- |
+| C | Input common (field-side return of the optocouplers) |
+| 3v3 | Fused 3.3 V for dry contacts / push buttons |
+| i1–i4 | Trigger inputs 1–4 |
+
+The inputs are opto-isolated and accept **3–24 VDC**. An input is **active when you apply a positive voltage** between that input (`i1`–`i4`) and `C`. They are **not** activated by pulling the pin to GND.
+
+Firmware on the RP2040 sees an active input as GPIO low (GPIO 8–11 for inputs 1–4).
+
+### Wiring a 3–24 V signal or PLC
+
+Connect the signal positive to `i1`–`i4` and the signal 0 V / return to `C`. Leave jumper J4 open if you want the input common isolated from board ground.
+
+### Wiring a dry contact or push button
+
+1. Fit a jumper on **J4** (see below) so `C` is connected to board GND.
+2. Wire the switch between the `3v3` pin and the input (`i1`–`i4`).
+
+## Digital outputs
+
+The output terminal is labeled `GND o4  o3 o2  o1`.
+
+| Pin | Function |
+| --- | --- |
+| o1–o4 | Open-collector / sinking outputs 1–4 (up to 30 VDC) |
+| GND | Board ground |
+
+These are sinking outputs: they pull the load to ground when on. Supply the load from an external voltage (up to 30 V) and return that supply to `GND`. Firmware uses GPIO 15–18 for outputs 1–4.
+
+## J3 DEBUG (SWD)
+
+J3 is the ARM Serial Wire Debug (SWD) port on the RP2040. It uses the same **3-pin JST SH 1.0 mm** connector as a Raspberry Pi Pico H / Raspberry Pi Debug Probe (`BM03B-SRSS-TB`).
+
+| Pin | Signal | J-Link |
+| --- | --- | --- |
+| 1 | SWCLK | SWCLK |
+| 2 | GND | GND |
+| 3 | SWDIO | SWDIO |
+
+The connector is keyed. Pin 1 is SWCLK, matching the Raspberry Pi Debug Probe 3-pin cable, so that cable plugs in directly.
+
+J3 does not include a target-voltage (VTref) pin. For a J-Link, take **3.3 V from the expansion header** into the J-Link VTref pin, in addition to SWCLK, SWDIO, and GND. There is no reset pin on J3; SWD attach without reset is enough.
+
+Mating parts if you are making your own cable: JST `SHR-03V-S-B` housing and `SSH-003T-P0.2` contacts.
+
+With the enclosure fitted, J3 is harder to reach. For day-to-day firmware updates, USB UF2 is easier (see [Software](software)).
+
+## J4 jumper
+
+J4 is a 2-pin 2.54 mm header next to the silkscreen **Connect C to GND**. Installing a jumper shorts the digital-input common (`C`) to board ground.
+
+* **Jumper fitted** — use this when powering buttons or dry contacts from the onboard `3v3` pin, or when you want the input return to be the same as board GND.
+* **Jumper open** — use this when an external 3–24 V source has its own 0 V connected to `C`, so the input common can stay separate from board ground.
+
 ## Expansion pins
 
 Can be used to extend the functionality of the Pico 2 by connecting a serial port, or I2C for example. Directly connected to the RP2040 GPIO 4 and 5, not protected. GND and 3.3V are also provided on these pins. Note the [errata](errata) for hardware revisions before v1.2.

--- a/src/content/docs/dmx-core-pico-2/software.md
+++ b/src/content/docs/dmx-core-pico-2/software.md
@@ -6,6 +6,26 @@ The Pico 2 runs software/firmware that you create yourself using the Raspberry P
 
 [Example code on GitHub](https://github.com/DMXCore/Pico-Examples)
 
+## Programming over USB (UF2)
+
+The RP2040 has a USB bootloader in ROM. There is no extra bootloader to install, and it cannot be overwritten.
+
+1. Hold the **BOOTSEL** button.
+2. Plug in USB-C (or power the board while still holding BOOTSEL).
+3. A drive named `RPI-RP2` appears. Copy your `.uf2` file onto it.
+
+The board reboots into the new firmware. The same flow is used for Pico C/C++ SDK builds, MicroPython, CircuitPython, and Arduino-produced UF2 files.
+
+You can also program and debug over the [J3 SWD port](pin-out/#j3-debug-swd) with a Raspberry Pi Debug Probe or a J-Link.
+
+## Arduino IDE
+
+Yes. Treat the board as a **Raspberry Pi Pico (RP2040)**, not a Raspberry Pi Pico 2 (RP2350). The DMX Core Pico 2 is RP2040-based.
+
+Recommended board package: [Earle Philhower's Raspberry Pi Pico / RP2040 core](https://github.com/earlephilhower/arduino-pico). Select board **Raspberry Pi Pico**, then upload via UF2 (BOOTSEL) or picotool.
+
+Use the GPIO numbers from the [examples](https://github.com/DMXCore/Pico-Examples) (for example digital inputs 1–4 are GPIO 8–11). The official Pico C/C++ SDK examples are the best-supported starting point if you are not already in Arduino.
+
 ## Commercial Software
 
 We have developed a software suite for the Pico 2 called the [DMX Re-Mapper](/dmx-core-pico-2-re-mapper/), which provides features like re-mapping of DMX channels and using digital inputs with a configuration utility. It's possible to purchase this software as an add-on to a standard Pico 2; the firmware is locked to the serial number of the Pico 2. [Contact DMX Pro Sales](https://dmxprosales.com/pages/contact-us) for more information about this upgrade.


### PR DESCRIPTION
## Summary
- Document J3 DEBUG as the RP2040 SWD port (JST SH 1.0 mm, pinout, J-Link / Debug Probe wiring).
- Explain jumper J4 (Connect C to GND), digital input polarity (3-24 V vs C, not pull-to-GND), and USB UF2 / Arduino IDE programming.

## Test plan
- [ ] Check https://docs.dmxcore.com/dmx-core-pico-2/pin-out/ for J3, J4, and digital I/O sections after deploy
- [ ] Check FAQ answers match the pin-out page
- [ ] Check Re-Mapper pin-out and FAQ link through to the Pico 2 hardware pages

Made with [Cursor](https://cursor.com)