### PR TITLE
Document signed Pico 2 Re-Mapper config apps

### DIFF
--- a/src/content/docs/dmx-core-pico-2-re-mapper/config-utility.md
+++ b/src/content/docs/dmx-core-pico-2-re-mapper/config-utility.md
@@ -5,12 +5,16 @@ description: Instructions on how to use the Config Utility
 
 ## Download
 
-Download the latest version of the Config Utility from [GitHub releases](https://github.com/DMXCore/Pico2ReMapper-Public/releases). Note that the current version of the config utility is text-based.
+Download the latest version of the Config Utility from [GitHub releases](https://github.com/DMXCore/Pico2ReMapper-Public/releases). The utility is a text-based menu in Terminal. Builds are portable (no installer, no auto-update) and signed by **DMX Pro Sales**.
 
 | Platform | File |
 |----------|------|
-| Windows | `DmxRemapperConfig.exe` |
-| macOS (Intel, or Apple Silicon via Rosetta) | `DmxRemapperMACOSX64.zip` |
+| Windows 64-bit | `DmxRemapperConfig.exe` |
+| Windows 32-bit | `DmxRemapperConfig-win-x86.exe` |
+| macOS Apple silicon (M1 or later) | `DmxRemapperConfig-osx-arm64.dmg` |
+| macOS Intel | `DmxRemapperConfig-osx-x64.dmg` |
+
+Plug the Pico 2 Re-Mapper in over USB before launching.
 
 ## Start the application
 
@@ -18,52 +22,23 @@ The Config Utility is a text-based, menu-driven application that interacts direc
 
 ### Windows
 
-Double-click `DmxRemapperConfig.exe`.
+Double-click `DmxRemapperConfig.exe` (or the 32-bit `DmxRemapperConfig-win-x86.exe`). Windows SmartScreen should show the publisher as **DMX Pro Sales**.
 
 ### macOS
 
-The macOS build is an unsigned command-line tool (not a signed `.app`), so macOS will not let it run until you mark it as executable and allow it through Gatekeeper. That is expected.
+1. Download the matching disk image (`osx-arm64` on Apple silicon, `osx-x64` on Intel).
+2. Open the `.dmg`.
+3. Double-click **DmxRemapperConfig** (the application). You can also drag it to **Applications**.
+4. Terminal opens with the text menus.
 
-1. Download `DmxRemapperMACOSX64.zip` and double-click it to unzip. Keep `DmxRemapperConfig` and `libSystem.IO.Ports.Native.dylib` in the same folder — do not run the `.zip` file itself.
-2. Open **Terminal** in that folder. In Finder you can right-click the folder and choose **New Terminal at Folder**, or `cd` to it.
-3. Run:
+Do **not** open files inside the application package, and do not use an older `.zip` that contains a raw Unix executable or a `.command` file. macOS Gatekeeper blocks those.
 
-```bash
-chmod +x DmxRemapperConfig
-xattr -d com.apple.quarantine DmxRemapperConfig
-./DmxRemapperConfig
-```
+The first time you launch, macOS may ask whether **Pico 2 Re-Mapper Config** can control Terminal. Choose **Allow**.
 
-The `./` prefix is required. If `xattr` reports that the quarantine attribute does not exist, that is fine — continue with `./DmxRemapperConfig`.
-
-On an Apple Silicon Mac (M1 or later), macOS runs this Intel (x64) build through Rosetta. If you are prompted to install Rosetta, accept it.
-
-#### "zsh: permission denied"
-
-This means the file is not marked executable, which is common after unzipping a download created on Windows. From the folder that contains `DmxRemapperConfig`:
-
-```bash
-chmod +x DmxRemapperConfig
-./DmxRemapperConfig
-```
-
-#### macOS says it cannot be opened / the developer cannot be verified
-
-Because the tool is not signed, Gatekeeper blocks it the first time. Use either of these:
-
-* In Finder, **Control-click** (or right-click) `DmxRemapperConfig`, choose **Open**, then **Open** again.
-* Or open **System Settings → Privacy & Security**, scroll to the message about `DmxRemapperConfig`, and choose **Open Anyway**.
-
-If Terminal still refuses to run it, remove the download quarantine flag and try again:
-
-```bash
-xattr -d com.apple.quarantine DmxRemapperConfig
-chmod +x DmxRemapperConfig
-./DmxRemapperConfig
-```
+If macOS offers **Move to Trash** instead of **Open**, you have an old unsigned download. Get a current `.dmg` from [GitHub releases](https://github.com/DMXCore/Pico2ReMapper-Public/releases).
 
 :::note
-The Config Utility is a terminal program. Running it from Terminal (as shown above) is the most reliable way to use the menus.
+YAML mapping files are written to the current working directory. When you launch from the application, that is your home folder.
 :::
 
 The menu options are:
@@ -105,7 +80,7 @@ Writes the current mapping (in RAM) to the device flash memory, making it perman
 
 ### Write Mapping to local file
 
-Writes the current mapping to a file named `Mapping_*******.yaml` in the current directory (the `*` part is the device serial number). The file can be opened with any text editor for bulk changes. The format is a list of output channels, each mapped to either `input-***` or `fixed-***`.
+Writes the current mapping to a file named `Mapping_*******.yaml` in the current directory (the `*` part is the device serial number). When you launch from the macOS application, that directory is your home folder. The file can be opened with any text editor for bulk changes. The format is a list of output channels, each mapped to either `input-***` or `fixed-***`.
 
 Example:
 

--- a/src/content/docs/dmx-core-pico-2-re-mapper/faq.md
+++ b/src/content/docs/dmx-core-pico-2-re-mapper/faq.md
@@ -29,17 +29,13 @@ It connects the digital-input common (`C`) to board ground. Fit it when using on
 
 At this time the firmware and config utility are not made available as open source.
 
-### I get "zsh: permission denied" when running DmxRemapperConfig on a Mac
+### macOS will not open the Config Utility / it offers Move to Trash
 
-The macOS download is not marked executable, and the tool is not signed. From the unzipped folder in Terminal:
+Use the current **`.dmg`** from [GitHub releases](https://github.com/DMXCore/Pico2ReMapper-Public/releases) (`osx-arm64` on Apple silicon, `osx-x64` on Intel). Open the disk image and double-click **DmxRemapperConfig** (the application). Do not run a raw Unix executable, a `.command` file, or an older `.zip`.
 
-```bash
-chmod +x DmxRemapperConfig
-xattr -d com.apple.quarantine DmxRemapperConfig
-./DmxRemapperConfig
-```
+The first launch may ask whether the app can control Terminal — choose **Allow**.
 
-See [Config Utility](/dmx-core-pico-2-re-mapper/config-utility/#macos) for the full macOS launch steps, including Gatekeeper ("developer cannot be verified").
+See [Config Utility](/dmx-core-pico-2-re-mapper/config-utility/#macos) for the full macOS launch steps.
 
 ### I have a suggestion for a new feature — can you add it?
 

--- a/src/content/docs/dmx-core-pico-2-re-mapper/index.md
+++ b/src/content/docs/dmx-core-pico-2-re-mapper/index.md
@@ -32,7 +32,7 @@ The 4 digital outputs are connected to DMX channels 1-4 on the DMX input. Any ti
 
 ### Configuration
 
-Configuration via text-based configuration tool, connected via USB to a Windows or Mac computer (see [releases](https://github.com/DMXCore/Pico2ReMapper-Public/releases) and [Config Utility](/dmx-core-pico-2-re-mapper/config-utility/)). Configuration is stored in a dedicated part of the 2MB flash memory. The config utility allows you to download/upload settings and store/load into YML text files locally on your computer.
+Configuration via a signed, text-based configuration tool on Windows or Mac, connected over USB (see [releases](https://github.com/DMXCore/Pico2ReMapper-Public/releases) and [Config Utility](/dmx-core-pico-2-re-mapper/config-utility/)). Configuration is stored in a dedicated part of the 2MB flash memory. The config utility allows you to download/upload settings and store/load into YML text files locally on your computer.
 
 ### Hardware
 

--- a/src/content/docs/dmx-core-pico-2-re-mapper/software.md
+++ b/src/content/docs/dmx-core-pico-2-re-mapper/software.md
@@ -6,4 +6,12 @@ The Re-Mapper firmware and configuration utility are available on GitHub:
 
 [Download from GitHub releases](https://github.com/DMXCore/Pico2ReMapper-Public/releases)
 
-The Windows config utility is `DmxRemapperConfig.exe`. On macOS, download `DmxRemapperMACOSX64.zip` and follow the [macOS launch steps](/dmx-core-pico-2-re-mapper/config-utility/#macos) — the tool is unsigned, so you will need to allow it to run.
+| File | Platform |
+|------|----------|
+| `dmxcorepico2-remapper.uf2` | Raspberry Pi Pico firmware (hold BOOTSEL, copy to the Pico drive) |
+| `DmxRemapperConfig.exe` | Windows 64-bit |
+| `DmxRemapperConfig-win-x86.exe` | Windows 32-bit |
+| `DmxRemapperConfig-osx-arm64.dmg` | macOS Apple silicon |
+| `DmxRemapperConfig-osx-x64.dmg` | macOS Intel |
+
+The config apps are portable, signed by DMX Pro Sales, and have no installer or auto-updater. On macOS, open the disk image and double-click **DmxRemapperConfig** (the application). See [Config Utility](/dmx-core-pico-2-re-mapper/config-utility/) for launch steps.


### PR DESCRIPTION
The Pico 2 Re-Mapper config utility is now a notarized macOS `.app` inside a stapled DMG (Apple silicon and Intel), plus signed Windows 64-bit and 32-bit exes. This replaces the old unsigned Intel zip (`DmxRemapperMACOSX64.zip`) and the chmod/xattr/Rosetta launch steps.

Pages updated:
- Config Utility — download table, Windows/macOS launch, Terminal permission, YAML files in the home folder
- Software — current release file names including UF2
- FAQ — Gatekeeper / Move to Trash instead of permission denied
- Product index — signed Windows or Mac tool
